### PR TITLE
style changes to front page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,7 +15,7 @@ layout: default
     {% include section_header.html content="Our Products" %}
     <ul class="post-list">
       {% for product in site.products %}
-        <li>
+        <li class="shady-box-shadow box-padding">
           <h3>
             <a href="{{ product.url | absolute_url }}">{{ product.name }}</a>
           </h3>
@@ -24,13 +24,16 @@ layout: default
             <p>{{ product.problem }}</p>
             <h4>Proposal</h4>
             <p>{{ product.proposal }}</p>
-            <p>Current Status: {{ product.status }}</p>
-          </div>
-          {% unless product == site.products.last %}
-            <br>
-            {{ "---" | markdownify }}
-          {% endunless %}
 
+            {% if product.status == "Active" %}
+              <p class="status active">Current Status: {{ product.status }}</p>
+            {% elsif product.status == "On Hold" %}
+              <p class="status on-hold">Current Status: {{ product.status }}</p>
+            {% else %}
+              <p class="status completed">Current Status: {{ product.status }}</p>
+            {% endif %}
+
+          </div>
         </li>
       {% endfor %}
     </ul>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -6,5 +6,12 @@ layout: default
 <p>{{ page.problem }}</p>
 <h2>Proposal</h2>
 <p>{{ page.proposal }}</p>
-<p>Status: {{ page.status }}
+
+{% if page.status == "Active" %}
+    <p class="status active">Status: {{ page.status }}</p>
+{% elsif page.status == "On Hold" %}
+    <p class="status on-hold">Status: {{ page.status }}</p>
+{% else %}
+    <p class="status completed">Status: {{ page.status }}</p>
+{% endif %}
 

--- a/_products/open_transit.md
+++ b/_products/open_transit.md
@@ -2,5 +2,5 @@
 name: OpenTransit
 problem: American public transit used to be the envy of the world, but has fallen behind in recent decades. Good public transit is essential to reducing income inequality, improving sustainability, and increasing accessibility.
 proposal: Use historical transit data to help riders and city planners understand the quality of bus, light rail, and streetcar lines. Currently offered in San Francisco and being adapted for PDX and beyond!
-status: Active
+status: On Hold
 ---

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -138,6 +138,24 @@ header {
   color: #073b7e;
 }
 
+/* Product Section */
+.box-padding {
+  padding: 15px 15px 5px 15px;
+}
+
+.status {
+  font-weight: bold;
+}
+.active {
+  color: green;
+}
+.on-hold {
+  color: red;
+}
+.completed {
+  color: purple;
+}
+
 /* Team Section */
 .profile-image {
   -webkit-border-radius: 100px;


### PR DESCRIPTION
## Purpose
1. Changed OpenTransit's status to "On Hold", resolves #13.
2. Added padding and box shadow border around products, resolves #4
3. Changed product status styles to different colors (red, green, purple), resolves #5.

## Screenshots
1. From open_transit.html
<img width="752"  alt="Webpage screenshot showing OpenTransit's status as being on hold" src="https://user-images.githubusercontent.com/31530784/97793732-293ba900-1bad-11eb-8285-f4ee3b0ffa7c.png">
2. From front page
<img width="500" alt="Screen Shot 2020-10-31 at 7 14 50 PM" src="https://user-images.githubusercontent.com/31530784/97793746-5c7e3800-1bad-11eb-98b2-25bdffbe0e02.png">
3. Examples from front page
<img width="179" alt="Screen Shot 2020-10-31 at 7 15 55 PM" src="https://user-images.githubusercontent.com/31530784/97793755-820b4180-1bad-11eb-83a5-8f3864582309.png">
<img width="219" alt="Screen Shot 2020-10-31 at 7 16 05 PM" src="https://user-images.githubusercontent.com/31530784/97793756-87688c00-1bad-11eb-966a-917bb8f5d654.png">
<img width="198" alt="Screen Shot 2020-10-31 at 7 17 02 PM" src="https://user-images.githubusercontent.com/31530784/97793763-a9620e80-1bad-11eb-9d20-e86d7ddbb853.png">
