### PR TITLE
Enable Jekyll livereload (#12)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ version: '3'
 services:
   web:
     build: .
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec jekyll serve --host '0.0.0.0'"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec jekyll serve --livereload --host '0.0.0.0'"
     volumes:
-      - .:/website-reboot
+      - .:/website_reboot
     ports:
       - "4000:4000"
+      - "35729:35729"
+


### PR DESCRIPTION
# Description
- Resolves *#12*
- Modified docker-compose.yml to use Jekyll's livereload functionality.
- Fix a typo in the docker-compose.yml volumes section ("website_reboot" instead of "website-reboot").

# Type of changes
- [X] Bug fix
- [X] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
